### PR TITLE
Sanitize initiative description in show view

### DIFF
--- a/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -87,7 +87,7 @@ edit_link(
       <br>
       <div class="row column">
         <%= render partial: "initiative_badge", locals: { initiative: current_initiative } %>
-        <%= description %>
+        <%= decidim_sanitize_editor description %>
 
         <%= render partial: "tags", locals: { resource: current_initiative } %>
       </div>


### PR DESCRIPTION
#### Description

Initiative description isn't sanitized anymore in the show view

#### Testing

* Log in
* Create a new initiative
* Publish initiative
* Navigate to the show view
* HTML tags should not be present in description content 